### PR TITLE
fix: Updates to support munki-facts

### DIFF
--- a/artifacts/active_directory_dns.py
+++ b/artifacts/active_directory_dns.py
@@ -5,7 +5,7 @@ factoid = 'active_directory_dns'
 def fact():
     '''Returns Active Directory DNS Domain Name'''
 
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, 'net', None, None)
     d = SCDynamicStoreCopyValue(

--- a/artifacts/active_directory_dsbindtimeout.py
+++ b/artifacts/active_directory_dsbindtimeout.py
@@ -6,13 +6,13 @@ factoid = 'active_directory_dsbindtimeout'
 def fact():
     '''Returns the dsbindtimeout setting'''
 
-    result = None
+    result = 'None'
     plist = '/Library/Preferences/com.apple.loginwindow.plist'
 
     if plist and os.path.exists(plist):
         result = CFPreferencesCopyAppValue('DSBindTimeout', plist)
 
-    return {factoid: result}
+    return {factoid: str(result)}
 
 if __name__ == '__main__':
     print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/active_directory_forest.py
+++ b/artifacts/active_directory_forest.py
@@ -4,7 +4,7 @@ factoid = 'active_directory_forest'
 
 def fact():
     '''Returns Active Directory forest'''
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, 'net', None, None)
     d = SCDynamicStoreCopyValue(

--- a/artifacts/active_directory_last_dc.py
+++ b/artifacts/active_directory_last_dc.py
@@ -7,7 +7,7 @@ factoid = 'active_directory_last_dc'
 def fact():
     '''Returns the last used domain controller'''
 
-    result = None
+    result = 'None'
     plist = None
 
     try:

--- a/artifacts/active_directory_node.py
+++ b/artifacts/active_directory_node.py
@@ -4,7 +4,7 @@ factoid = 'active_directory_node'
 
 def fact():
     '''Returns Active Directory node'''
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, 'net', None, None)
     d = SCDynamicStoreCopyValue(

--- a/artifacts/active_directory_trust_account.py
+++ b/artifacts/active_directory_trust_account.py
@@ -4,7 +4,7 @@ factoid = 'active_directory_trust_account'
 
 def fact():
     '''Returns Active Directory trust account'''
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, 'net', None, None)
     d = SCDynamicStoreCopyValue(

--- a/artifacts/battery_cycles.py
+++ b/artifacts/battery_cycles.py
@@ -6,7 +6,7 @@ factoid = 'battery_cycles'
 def fact():
     '''Returns the battery cycle count'''
 
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/battery_health.py
+++ b/artifacts/battery_health.py
@@ -6,7 +6,7 @@ factoid = 'battery_health'
 def fact():
     '''Returns the battery health'''
 
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/battery_percentage.py
+++ b/artifacts/battery_percentage.py
@@ -7,7 +7,7 @@ factoid = 'battery_percentage'
 def fact():
     '''Returns the battery percentage'''
 
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/battery_status.py
+++ b/artifacts/battery_status.py
@@ -6,7 +6,7 @@ factoid = 'battery_status'
 def fact():
     '''Returns the battery charging status'''
 
-    result = None
+    result = 'None'
     charged, charging = None, None
 
     try:

--- a/artifacts/bluetooth_sharing.py
+++ b/artifacts/bluetooth_sharing.py
@@ -6,7 +6,7 @@ factoid = 'bluetooth_sharing'
 def fact():
     '''Returns the current bluetooth sharing'''
 
-    result = None
+    result = 'None'
 
     objc.loadBundle("IOBluetooth", globals(), bundle_path=objc.pathForFramework(u'/System/Library/Frameworks/IOBluetooth.framework'))
     btprefs = IOBluetoothPreferences.alloc().init()

--- a/artifacts/boot_age.py
+++ b/artifacts/boot_age.py
@@ -6,7 +6,7 @@ factoid = 'boot_age'
 def fact():
     '''Returns the number of days since last boot'''
 
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/boot_date.py
+++ b/artifacts/boot_date.py
@@ -6,7 +6,7 @@ factoid = 'boot_date'
 def fact():
     '''Returns the system boot time'''
 
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/boot_rom_version.py
+++ b/artifacts/boot_rom_version.py
@@ -6,7 +6,7 @@ factoid = 'boot_rom_version'
 def fact():
     '''Returns the boot rom version'''
 
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/boot_volume.py
+++ b/artifacts/boot_volume.py
@@ -5,7 +5,7 @@ factoid = 'boot_volume'
 
 def fact():
     '''Returns the boot volume'''
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/bootcamp_status.py
+++ b/artifacts/bootcamp_status.py
@@ -6,7 +6,7 @@ factoid = 'bootcamp_status'
 def fact():
     '''Returns bootcamp status'''
 
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/build_version.py
+++ b/artifacts/build_version.py
@@ -5,7 +5,7 @@ factoid = 'build_version'
 
 def fact():
     '''Returns the macOS build version'''
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(

--- a/artifacts/cidr.py
+++ b/artifacts/cidr.py
@@ -43,7 +43,7 @@ def ip_address(iface, net_config, addresses=[]):
 def fact():
     '''Returns the cidr of the current vlan'''
 
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, 'net', None, None)
     ip, primary_interface, netmask = '', '', ''

--- a/artifacts/computername.py
+++ b/artifacts/computername.py
@@ -4,7 +4,7 @@ factoid = 'computername'
 
 def fact():
     '''Returns the ComputerName'''
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, "net", None, None)
     sys_info = SCDynamicStoreCopyValue(net_config, "Setup:/System")

--- a/artifacts/directory_contacts_node.py
+++ b/artifacts/directory_contacts_node.py
@@ -4,7 +4,7 @@ factoid = 'directory_contacts_node'
 
 def fact():
     '''Returns the directory search node info'''
-    result = None
+    result = 'None'
     net_config = SCDynamicStoreCreate(None, "net", None, None)
 
     contacts_node = SCDynamicStoreCopyValue(

--- a/artifacts/directory_search_node.py
+++ b/artifacts/directory_search_node.py
@@ -4,7 +4,7 @@ factoid = 'directory_search_node'
 
 def fact():
     '''Returns the directory search node info'''
-    result = None
+    result = 'None'
     net_config = SCDynamicStoreCreate(None, "net", None, None)
 
     search_node = SCDynamicStoreCopyValue(net_config,

--- a/artifacts/dns_domain.py
+++ b/artifacts/dns_domain.py
@@ -4,7 +4,7 @@ factoid = 'dns_domain'
 
 def fact():
     '''Returns the current dns domain'''
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, "net", None, None)
     dns_info = SCDynamicStoreCopyValue(net_config, "State:/Network/Global/DNS")
@@ -14,7 +14,7 @@ def fact():
         except KeyError:
             pass
 
-    return {factoid: result}
+    return {factoid: str(result)}
 
 if __name__ == '__main__':
     print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/external_ip.py
+++ b/artifacts/external_ip.py
@@ -4,7 +4,7 @@ factoid = 'external_ip'
 
 def fact():
     '''Returns the external IP of this Mac'''
-    result = None
+    result = 'None'
 
     url = 'http://ipecho.net/plain'
     url = 'http://icanhazip.com'

--- a/artifacts/firewall_status.py
+++ b/artifacts/firewall_status.py
@@ -4,7 +4,7 @@ factoid = 'firewall_status'
 
 def fact():
     '''Returns the firewall status'''
-    result = None
+    result = 'None'
 
     plist = '/Library/Preferences/com.apple.alf.plist'
     firewall_status = CFPreferencesCopyAppValue('globalstate', plist)

--- a/artifacts/freespace.py
+++ b/artifacts/freespace.py
@@ -5,7 +5,7 @@ factoid = 'freespace'
 
 def fact():
     '''Returns the free space of the boot drive of this Mac'''
-    result = None
+    result = 'None'
     try:
         proc = subprocess.Popen(['/usr/sbin/diskutil', 'info', '-plist', '/'],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/artifacts/gatekeeper_date.py
+++ b/artifacts/gatekeeper_date.py
@@ -9,7 +9,7 @@ factoid = 'gatekeeper_date'
 
 def fact():
     '''Returns the modification date of the gatekeeper package'''
-    result = None
+    result = 'None'
 
     try:
         gkpkgs = subprocess.check_output(['/usr/sbin/pkgutil',

--- a/artifacts/gatekeeper_status.py
+++ b/artifacts/gatekeeper_status.py
@@ -4,7 +4,7 @@ factoid = 'gatekeeper_status'
 
 def fact():
     '''Return the current Gatekeeper status'''
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(['/usr/sbin/spctl', '--status'],

--- a/artifacts/hardware_model.py
+++ b/artifacts/hardware_model.py
@@ -4,7 +4,7 @@ factoid = 'hardware_model'
 
 def fact():
     '''Returns the hardware model'''
-    result = None
+    result = 'None'
 
     try:
         proc = subprocess.Popen(['/usr/sbin/sysctl', '-n', 'hw.model'],

--- a/artifacts/hostname.py
+++ b/artifacts/hostname.py
@@ -4,7 +4,7 @@ factoid = 'hostname'
 
 def fact():
     '''Returns the value of the hostname of this Mac'''
-    result = None
+    result = 'None'
 
     net_config = SCDynamicStoreCreate(None, "net", None, None)
     sys_info = SCDynamicStoreCopyValue(net_config, "Setup:/System")

--- a/artifacts/icloud_account.py
+++ b/artifacts/icloud_account.py
@@ -6,7 +6,7 @@ factoid = 'icloud_account'
 
 def fact():
     '''Returns the icloud account'''
-    result = None
+    result = 'None'
 
     console_user = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
     plist = '/Users/%s/Library/Preferences/MobileMeAccounts.plist' % console_user

--- a/artifacts/icloud_display_name.py
+++ b/artifacts/icloud_display_name.py
@@ -6,7 +6,7 @@ factoid = 'icloud_display_name'
 
 def fact():
     '''Returns the icloud display name'''
-    result = None
+    result = 'None'
 
     console_user = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
     plist = '/Users/%s/Library/Preferences/MobileMeAccounts.plist' % console_user

--- a/artifacts/icloud_drive.py
+++ b/artifacts/icloud_drive.py
@@ -6,7 +6,7 @@ factoid = 'icloud_drive'
 
 def fact():
     '''Returns the icloud drive status'''
-    result = None
+    result = 'None'
     console_user = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
     plist = '/Users/%s/Library/Preferences/MobileMeAccounts.plist' % console_user
     if os.path.exists(plist):

--- a/artifacts/icloud_optimization.py
+++ b/artifacts/icloud_optimization.py
@@ -7,7 +7,7 @@ factoid = 'icloud_optimization'
 def fact():
     '''Returns the iCloud disk optimization status'''
 
-    result = None
+    result = 'None'
 
     console_user = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
     plist = '/Users/%s/Library/Preferences/com.apple.bird.plist' % console_user

--- a/artifacts/icloud_status.py
+++ b/artifacts/icloud_status.py
@@ -6,7 +6,7 @@ factoid = 'icloud_status'
 
 def fact():
     '''Returns the icloud status'''
-    result = None
+    result = 'None'
     console_user = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
     plist = '/Users/%s/Library/Preferences/MobileMeAccounts.plist' % console_user
     if os.path.exists(plist):

--- a/artifacts/is_virtual.py
+++ b/artifacts/is_virtual.py
@@ -4,7 +4,7 @@ factoid = 'is_virtual'
 
 def fact():
     '''Returns whether the system is a virtual machine'''
-    result = None
+    result = 'None'
     try:
         proc = subprocess.Popen(['/usr/sbin/sysctl', '-n', 'machdep.cpu.features'],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/artifacts/java_plugin_version.py
+++ b/artifacts/java_plugin_version.py
@@ -5,7 +5,7 @@ factoid = 'java_plugin_version'
 
 def fact():
     '''Returns the java plugin version'''
-    result = None
+    result = 'None'
 
     plist = '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Info.plist'
     if os.path.exists(plist):

--- a/artifacts/java_vendor.py
+++ b/artifacts/java_vendor.py
@@ -5,7 +5,7 @@ factoid = 'java_vendor'
 
 def fact():
     '''Returns the java vendor (apple or oracle)'''
-    result = None
+    result = 'None'
 
     plist = '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Info.plist'
     if os.path.exists(plist):

--- a/artifacts/mrt_date.py
+++ b/artifacts/mrt_date.py
@@ -6,7 +6,7 @@ factoid = 'mrt_date'
 
 def fact():
     '''Returns the last date mrt was updated'''
-    result = None
+    result = 'None'
 
     try:
         cmd = ['/usr/sbin/pkgutil', '--pkgs=.*MRT.*']

--- a/artifacts/network_interfaces.py
+++ b/artifacts/network_interfaces.py
@@ -14,7 +14,8 @@ def fact():
             SCNetworkInterfaceGetBSDName(interface),
             SCNetworkInterfaceGetHardwareAddressString(interface)
             )
-    return {factoid: interfaces}
+
+    return {factoid: str(interfaces)}
 
 if __name__ == '__main__':
     print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/password_changed.py
+++ b/artifacts/password_changed.py
@@ -7,7 +7,7 @@ factoid = 'password_changed'
 
 def fact():
     '''Gets the date of last password change'''
-    password_changed = None
+    password_changed = 'None'
 
     # for 10.10+ or non-migrated accounts
     username = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
@@ -29,7 +29,7 @@ def fact():
                 if 'passwordLastSetTime' in plist.keys():
                     password_changed = plist['passwordLastSetTime'].date()
 
-    return {factoid: password_changed}
+    return {factoid: str(password_changed)}
 
 if __name__ == '__main__':
     print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/sentinel_connection.py
+++ b/artifacts/sentinel_connection.py
@@ -4,7 +4,7 @@ factoid = 'sentinel_connection'
 
 def fact():
     '''Returns the sentinel connection'''
-    last_seen = None
+    last_seen = 'None'
     binary = '/usr/local/bin/sentinelctl'
     if os.path.exists(binary) and os.getuid() == 0:
         try:

--- a/artifacts/sentinel_last_seen.py
+++ b/artifacts/sentinel_last_seen.py
@@ -4,7 +4,7 @@ factoid = 'sentinel_last_seen'
 
 def fact():
     '''Returns the sentinel last checkin'''
-    last_seen = None
+    last_seen = 'None'
     binary = '/usr/local/bin/sentinelctl'
     if os.path.exists(binary) and os.getuid() == 0:
         try:

--- a/artifacts/sentinel_server.py
+++ b/artifacts/sentinel_server.py
@@ -4,7 +4,7 @@ factoid = 'sentinel_server'
 
 def fact():
     '''Returns the sentinel server'''
-    server = None
+    server = 'None'
     binary = '/usr/local/bin/sentinelctl'
     if os.path.exists(binary) and os.getuid() == 0:
         try:

--- a/artifacts/sentinel_version.py
+++ b/artifacts/sentinel_version.py
@@ -5,7 +5,7 @@ factoid = 'sentinel_version'
 
 def fact():
     '''Returns the sentinel version'''
-    version = None
+    version = 'None'
     plist = '/Library/Sentinel/sentinel-agent.bundle/Contents/Info.plist'
     if os.path.exists(plist):
         version = CFPreferencesCopyAppValue('CFBundleShortVersionString', plist)

--- a/artifacts/software_update_server.py
+++ b/artifacts/software_update_server.py
@@ -4,12 +4,12 @@ factoid = 'software_update_server'
 
 def fact():
     '''Returns the software update server'''
-    sus = None
+    sus = 'None'
 
     sus = CFPreferencesCopyAppValue('CatalogURL',
                     '/Library/Preferences/com.apple.SoftwareUpdate.plist')
 
-    return {factoid: sus}
+    return {factoid: str(sus)}
 
 if __name__ == '__main__':
     print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/xprotect_date.py
+++ b/artifacts/xprotect_date.py
@@ -7,7 +7,7 @@ factoid = 'xprotect_date'
 def fact():
     '''Returns the last date xprotect was updated'''
 
-    result = None
+    result = 'None'
 
     try:
         cmd = ['/usr/sbin/pkgutil', '--pkgs=.*XProtect.*']

--- a/artifacts/xprotect_version.py
+++ b/artifacts/xprotect_version.py
@@ -6,7 +6,7 @@ factoid = 'xprotect_version'
 def fact():
     '''Returns the xprotect version'''
 
-    result = None
+    result = 'None'
     path = '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProtect.meta.plist'
 
     if os.path.exists(path):


### PR DESCRIPTION
Munki facts will take the result of the fact and dump it into a plist file. As such the python None type needs to be converted to a string.

I tested each fact and found a few that interacted with CFPreferences so the result is manually casted to string on a handful of files.