### PR TITLE
fix: Correct Gatekeeper Data fact

### DIFF
--- a/artifacts/gatekeeper_date.py
+++ b/artifacts/gatekeeper_date.py
@@ -21,7 +21,7 @@ def fact():
             pkginfo       = plistlib.readPlistFromString(pkginfo_plist)
             dates.append(pkginfo['install-time'])
         result = time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime(max(dates)))
-    except (OSError, IOError):
+    except (OSError, IOError, subprocess.CalledProcessError):
         pass
 
     return {factoid: result}


### PR DESCRIPTION
It's possible your machine is so fresh it hasn't actually ran
softwareupdate in order get a new version of Gatekeeper.