### PR TITLE
add 6 artifacts to report on software updates

### DIFF
--- a/artifacts/drive_medium.py
+++ b/artifacts/drive_medium.py
@@ -1,41 +1,31 @@
 import subprocess
 import plistlib
 
-factoid = "drive_medium"
+factoid = 'drive_medium'
 
 def fact():
-    '''
-    Returns the medium type for the boot drive of this Mac
-
-    Values include 'fusion', 'rotational', 'ssd' or 'None'
-    '''
+    '''Returns the boot drive medium'''
     result = 'None'
+
     try:
-        # Check for Fusion drive
-        proc = subprocess.Popen(['/usr/sbin/diskutil', 'cs', 'list'],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+                ['/usr/sbin/diskutil', 'info', '-plist', '/'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+                )
         stdout, _ = proc.communicate()
-        if 'Fusion' in stdout:
-            result = 'fusion'
-        else:
-            # Determine rotational vs ssd
-            proc = subprocess.Popen(['/usr/sbin/system_profiler', '-xml',
-                                        'SPStorageDataType'],
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
-            stdout, _ = proc.communicate()
-            xml = plistlib.readPlistFromString(stdout)
-            drives = xml[0]['_items']
-            for drive in drives:
-                if drive['mount_point'] == '/':
-                    # Check for CoreStorage physical volume
-                    try:
-                        result = drive['com.apple.corestorage.pv'][0]['medium_type']
-                    except KeyError:
-                        result = drive['physical_drive']['medium_type']
     except (IOError, OSError):
-        pass
-    
+        stdout = None
+
+    if stdout:
+        d = plistlib.readPlistFromString(stdout.strip())
+        if d.get('CoreStorageCompositeDisk', False):
+            result = 'fusion'
+        elif d.get('RAIDMaster', False):
+            result = 'raid'
+        else:
+            result = 'ssd' if d.get('SolidState', False) else 'rotational'
+
     return {factoid: result}
 
 if __name__ == '__main__':

--- a/artifacts/drive_medium.py
+++ b/artifacts/drive_medium.py
@@ -30,7 +30,7 @@ def fact():
                 if drive['mount_point'] == '/':
                     # Check for CoreStorage physical volume
                     try:
-                        result = drive[0]['com.apple.corestorage.pv']['medium_type']
+                        result = drive['com.apple.corestorage.pv'][0]['medium_type']
                     except KeyError:
                         result = drive['physical_drive']['medium_type']
     except (IOError, OSError):

--- a/artifacts/updates_app_autoupdate.py
+++ b/artifacts/updates_app_autoupdate.py
@@ -1,0 +1,16 @@
+from CoreFoundation import CFPreferencesCopyAppValue
+
+factoid = 'updates_app_autoupdate'
+
+def fact():
+    '''Returns the status of automatic updates to MAS apps'''
+    status = "disabled"
+    pref = CFPreferencesCopyAppValue('AutoUpdate',
+                    '/Library/Preferences/com.apple.commerce.plist')
+    if pref:
+        status = "enabled"
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/updates_check_status.py
+++ b/artifacts/updates_check_status.py
@@ -1,0 +1,19 @@
+from CoreFoundation import CFPreferencesCopyAppValue
+
+factoid = 'updates_check_status'
+
+def fact():
+    '''
+    Reports the overall status of automatic update checking for OS X updates,
+    App Store app updates, and Gatekeeper and XProtect configurations
+    '''
+    status = "disabled"
+    pref = CFPreferencesCopyAppValue('AutomaticCheckEnabled',
+                    '/Library/Preferences/com.apple.SoftwareUpdate')
+    if pref:
+        status = "enabled"
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/updates_config_data.py
+++ b/artifacts/updates_config_data.py
@@ -1,0 +1,16 @@
+from CoreFoundation import CFPreferencesCopyAppValue
+
+factoid = 'updates_config_data'
+
+def fact():
+    '''Returns the status of automatic installation of config data'''
+    status = "disabled"
+    pref = CFPreferencesCopyAppValue('ConfigDataInstall',
+                    '/Library/Preferences/com.apple.SoftwareUpdate')
+    if pref:
+        status = "enabled"
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/updates_critical.py
+++ b/artifacts/updates_critical.py
@@ -1,0 +1,16 @@
+from CoreFoundation import CFPreferencesCopyAppValue
+
+factoid = 'updates_critical'
+
+def fact():
+    '''Returns the status of automatic installation of critical updates'''
+    status = "disabled"
+    pref = CFPreferencesCopyAppValue('CriticalUpdateInstall',
+                    '/Library/Preferences/com.apple.SoftwareUpdate')
+    if pref:
+        status = "enabled"
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/updates_software_download.py
+++ b/artifacts/updates_software_download.py
@@ -1,0 +1,16 @@
+from CoreFoundation import CFPreferencesCopyAppValue
+
+factoid = 'updates_software_download'
+
+def fact():
+    '''Returns the status of automatic downloading of software updates'''
+    status = "disabled"
+    pref = CFPreferencesCopyAppValue('AutomaticDownload',
+                    '/Library/Preferences/com.apple.SoftwareUpdate')
+    if pref:
+        status = "enabled"
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/updates_software_installation.py
+++ b/artifacts/updates_software_installation.py
@@ -1,0 +1,16 @@
+from CoreFoundation import CFPreferencesCopyAppValue
+
+factoid = 'updates_software_installation'
+
+def fact():
+    '''Returns the status of automatic installation of downloaded updates'''
+    status = "disabled"
+    pref = CFPreferencesCopyAppValue('AutoUpdateRestartRequired',
+                    '/Library/Preferences/com.apple.commerce.plist')
+    if pref:
+        status = "enabled"
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]


### PR DESCRIPTION
Report on:

- status of automatic updates to MAS apps
- overall status of automatic update checking for OS X updates, App Store app updates, and Gatekeeper and XProtect configurations
- status of automatic installation of config data
- status of automatic installation of critical updates
- status of automatic downloading of software updates
- status of automatic installation of downloaded updates

Sample output:

```
updates_app_autoupdate => enabled
updates_check_status => enabled
updates_config_data => enabled
updates_critical => enabled
updates_software_download => enabled
updates_software_installation => enabled
```