### PR TITLE
update com.apple.commerce preference checks to account for per-user settings

### DIFF
--- a/artifacts/updates_app_autoupdate.py
+++ b/artifacts/updates_app_autoupdate.py
@@ -1,12 +1,16 @@
-from CoreFoundation import CFPreferencesCopyAppValue
+#!/usr/bin/env python
+
+from CoreFoundation import (CFPreferencesCopyValue, kCFPreferencesAnyHost, 
+kCFPreferencesAnyUser)
 
 factoid = 'updates_app_autoupdate'
 
 def fact():
     '''Returns the status of automatic updates to MAS apps'''
     status = "disabled"
-    pref = CFPreferencesCopyAppValue('AutoUpdate',
-                    '/Library/Preferences/com.apple.commerce.plist')
+    pref = CFPreferencesCopyValue('AutoUpdate',
+                    '/Library/Preferences/com.apple.commerce.plist',
+                    kCFPreferencesAnyUser, kCFPreferencesAnyHost)
     if pref:
         status = "enabled"
 

--- a/artifacts/updates_software_installation.py
+++ b/artifacts/updates_software_installation.py
@@ -1,12 +1,16 @@
-from CoreFoundation import CFPreferencesCopyAppValue
+#!/usr/bin/env python
 
-factoid = 'updates_software_installation'
+from CoreFoundation import (CFPreferencesCopyValue, kCFPreferencesAnyHost, 
+kCFPreferencesAnyUser)
+
+factoid = 'updates_app_autoupdate'
 
 def fact():
-    '''Returns the status of automatic installation of downloaded updates'''
+    '''Returns the status of automatic updates to MAS apps'''
     status = "disabled"
-    pref = CFPreferencesCopyAppValue('AutoUpdateRestartRequired',
-                    '/Library/Preferences/com.apple.commerce.plist')
+    pref = CFPreferencesCopyValue('AutoUpdateRestartRequired',
+                    '/Library/Preferences/com.apple.commerce.plist',
+                    kCFPreferencesAnyUser, kCFPreferencesAnyHost)
     if pref:
         status = "enabled"
 


### PR DESCRIPTION
I noticed some inconsistencies on macOS High Sierra when reporting on the preferences in `/Library/Preferences/com.apple.commerce.plist`. A user can disable "Install app updates" and/or "Install macOS updates" in _System Preferences_ > _App Store_, but the previous artifacts might incorrectly report the setting is still enabled at the system level.

![2017-10-10 at 11 23 pm](https://user-images.githubusercontent.com/3910/31420890-368145c2-ae12-11e7-863a-3a5db7d855d1.png)

The updated artifacts for `updates_app_autoupdate.py` and `updates_software_installation.py` now use `kCFPreferencesAnyHost` and `kCFPreferencesAnyUser` to more consistently report on the state of the system.