### PR TITLE
PR to add AFP and SMB file sharing statuses

### DIFF
--- a/artifacts/file_sharing_status_afp.py
+++ b/artifacts/file_sharing_status_afp.py
@@ -1,0 +1,20 @@
+import subprocess
+
+factoid = 'file_sharing_status_afp'
+
+def fact():
+    '''Returns the status of AFP file sharing'''
+    try:
+        status = False
+        proc = subprocess.Popen(['/bin/launchctl', 'list'],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result, _ = proc.communicate()
+        if 'com.apple.AppleFileServer' in result:
+            status = True
+    except (IOError, OSError):
+        status = 'Unknown'
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]

--- a/artifacts/file_sharing_status_smb.py
+++ b/artifacts/file_sharing_status_smb.py
@@ -1,0 +1,20 @@
+import subprocess
+
+factoid = 'file_sharing_status_smb'
+
+def fact():
+    '''Returns the status of SMB file sharing'''
+    try:
+        status = False
+        proc = subprocess.Popen(['/bin/launchctl', 'list'],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result, _ = proc.communicate()
+        if 'com.apple.smbd' in result:
+            status = True
+    except (IOError, OSError):
+        status = 'Unknown'
+
+    return {factoid: status}
+
+if __name__ == '__main__':
+    print '<result>%s</result>' % fact()[factoid]


### PR DESCRIPTION
Added artifacts to report `True`, `False`, or `Unknown` on status of both AFP and SMB file sharing.